### PR TITLE
Fix compile error in windows-static build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,7 @@
 cmake_minimum_required(VERSION 2.8)
 
+option(ENABLE_USB "Enable usb support" ON)
+
 if(${CMAKE_SYSTEM_NAME} MATCHES "Linux")
   include("linux.cmake")
 elseif(${CMAKE_SYSTEM_NAME} MATCHES "Windows")

--- a/Sources/include/private/ltme01_sdk/usb/UsbTransport.h
+++ b/Sources/include/private/ltme01_sdk/usb/UsbTransport.h
@@ -1,4 +1,4 @@
-#ifndef USB_TRANSPORT_H
+#if !defined(USB_TRANSPORT_H) && defined(ENABLE_USB)
 #define USB_TRANSPORT_H
 
 #include "ltme01_sdk/Transport.h"

--- a/Sources/include/public/ltme01_sdk/DataPacket.h
+++ b/Sources/include/public/ltme01_sdk/DataPacket.h
@@ -54,7 +54,7 @@ private:
 #pragma pack(pop)
 
   DataPacketHeader* header_;
-  uint8_t data_[MAX_DATA_PACKET_SIZE];
+  uint8_t data_[MAX_DATA_PACKET_SIZE] = {0};
 };
 
 }

--- a/Sources/include/public/ltme01_sdk/usb/UsbLocation.h
+++ b/Sources/include/public/ltme01_sdk/usb/UsbLocation.h
@@ -1,4 +1,4 @@
-#ifndef USB_LOCATION_H
+#if !defined(USB_LOCATION_H) && defined(ENABLE_USB)
 #define USB_LOCATION_H
 
 #include "ltme01_sdk/Common.h"

--- a/Sources/include/public/ltme01_sdk/util/DeviceNotifier.h
+++ b/Sources/include/public/ltme01_sdk/util/DeviceNotifier.h
@@ -37,7 +37,9 @@ private:
   std::thread thread_;
   bool activeFlag_;
 
+#ifdef ENABLE_USB
   std::unique_ptr<UsbDeviceScanner> usbDeviceScanner_;
+#endif
   std::unique_ptr<LanDeviceScanner> lanDeviceScanner_;
 
   std::vector<DeviceInfo> devices_;

--- a/Sources/src/DeviceInfo.cpp
+++ b/Sources/src/DeviceInfo.cpp
@@ -29,10 +29,11 @@ ltme01_sdk::DeviceType ltme01_sdk::DeviceInfo::type() const
 {
   const Location& location = *location_;
 
+#ifdef ENABLE_USB
   if (typeid(location) == typeid(UsbLocation))
     return DEVICE_TYPE_USB;
-  else
-    return DEVICE_TYPE_LAN;
+#endif
+  return DEVICE_TYPE_LAN;
 }
 
 const ltme01_sdk::Location& ltme01_sdk::DeviceInfo::location() const

--- a/Sources/src/Transport.cpp
+++ b/Sources/src/Transport.cpp
@@ -10,10 +10,11 @@
 
 ltme01_sdk::Transport* ltme01_sdk::Transport::createInstance(const Location& location)
 {
+#ifdef ENABLE_USB
   if (typeid(location) == typeid(UsbLocation))
     return new UsbTransport(dynamic_cast<const UsbLocation&>(location));
-  else if (typeid(location) == typeid(LanLocation))
+#endif
+  if (typeid(location) == typeid(LanLocation))
     return new LanTransport(dynamic_cast<const LanLocation&>(location));
-  else
-    return NULL;
+  return NULL;
 }

--- a/Sources/src/usb/UsbLocation.cpp
+++ b/Sources/src/usb/UsbLocation.cpp
@@ -1,3 +1,4 @@
+#ifdef ENABLE_USB
 #include "ltme01_sdk/usb/UsbLocation.h"
 
 #include <sstream>
@@ -57,3 +58,4 @@ uint8_t ltme01_sdk::UsbLocation::deviceAddress() const
 {
   return deviceAddress_;
 }
+#endif // ENABLE_USB

--- a/Sources/src/usb/UsbTransport.cpp
+++ b/Sources/src/usb/UsbTransport.cpp
@@ -1,3 +1,4 @@
+#ifdef ENABLE_USB
 #include "ltme01_sdk/usb/UsbTransport.h"
 
 #include "ltme01_sdk/Device.h"
@@ -317,3 +318,4 @@ void ltme01_sdk::UsbTransport::ctrlEndpointRxCallback(libusb_transfer* transfer)
   waitItem->cv.notify_one();
   lock.unlock();
 }
+#endif

--- a/Sources/src/util/DeviceNotifier.cpp
+++ b/Sources/src/util/DeviceNotifier.cpp
@@ -5,7 +5,9 @@
 
 #include "ltme01_sdk/ControlPacket.h"
 
+#ifdef ENABLE_USB
 #include <libusb-1.0/libusb.h>
+#endif
 
 #include <asio.hpp>
 
@@ -22,6 +24,7 @@ public:
   virtual std::vector<DeviceInfo> scanDevices() = 0;
 };
 
+#ifdef ENABLE_USB
 class UsbDeviceScanner : public DeviceScanner
 {
 public:
@@ -70,6 +73,7 @@ std::vector<DeviceInfo> UsbDeviceScanner::scanDevices()
 
   return devices;
 }
+#endif
 
 class LanDeviceScanner : public DeviceScanner
 {
@@ -158,7 +162,9 @@ void LanDeviceScanner::responsePacketHandler(const asio::error_code& error, size
 
 ltme01_sdk::DeviceNotifier::DeviceNotifier()
   : activeFlag_(false)
+#ifdef ENABLE_USB
   , usbDeviceScanner_(new UsbDeviceScanner)
+#endif
   , lanDeviceScanner_(new LanDeviceScanner)
 {
 }
@@ -180,8 +186,10 @@ void ltme01_sdk::DeviceNotifier::start()
   thread_ = std::thread([&]() {
     while (activeFlag_) {
       std::vector<DeviceInfo> currentDevices;
+#ifdef ENABLE_USB
       std::vector<DeviceInfo> usbDevices = usbDeviceScanner_->scanDevices();
       currentDevices.insert(currentDevices.end(), usbDevices.begin(), usbDevices.end());
+#endif
       std::vector<DeviceInfo> lanDevices = lanDeviceScanner_->scanDevices();
       currentDevices.insert(currentDevices.end(), lanDevices.begin(), lanDevices.end());
 

--- a/linux.cmake
+++ b/linux.cmake
@@ -2,38 +2,44 @@ cmake_minimum_required(VERSION 2.8)
 
 add_compile_options(-std=c++11)
 
-set(LIBUSB_DIR "${CMAKE_CURRENT_SOURCE_DIR}/ThirdParty/libusb/linux/libusb-1.0.21")
 set(SDK_INCLUDE_DIR "${CMAKE_CURRENT_SOURCE_DIR}/Sources/include")
 set(SDK_SRC_DIR "${CMAKE_CURRENT_SOURCE_DIR}/Sources/src")
 
 FILE(GLOB_RECURSE SDK_SRC "${SDK_SRC_DIR}/*.cpp")
 
-include(ExternalProject)
-ExternalProject_Add(libusb-1.0.21
-  SOURCE_DIR ${LIBUSB_DIR}
-  PATCH_COMMAND "bash"
-    "-c"
-    "! [ -x ${LIBUSB_DIR}/configure ] && chmod +x ${LIBUSB_DIR}/configure || :"
-  CONFIGURE_COMMAND "${LIBUSB_DIR}/configure"
-    "CFLAGS=-fPIC"
-    "--prefix=${CMAKE_CURRENT_BINARY_DIR}/ThirdParty/libusb-1.0.21"
-    "--enable-shared=no"
-    "--enable-static=yes"
-  BUILD_COMMAND "bash"
-    "-c"
-    "(make check &> /dev/null || touch ${LIBUSB_DIR}/aclocal.m4 ${LIBUSB_DIR}/Makefile.in ${LIBUSB_DIR}/configure ${LIBUSB_DIR}/config.h.in) && make"
-  INSTALL_COMMAND make install
-)
-
 project(ltme01_sdk)
 add_definitions(-DASIO_STANDALONE)
 add_library(${PROJECT_NAME} ${SDK_SRC})
 set_target_properties(${PROJECT_NAME} PROPERTIES PREFIX "")
-add_dependencies(${PROJECT_NAME} libusb-1.0.21)
 target_include_directories(${PROJECT_NAME}
   PUBLIC "${SDK_INCLUDE_DIR}/public"
   PRIVATE "${SDK_INCLUDE_DIR}/private"
-  PRIVATE "${CMAKE_CURRENT_BINARY_DIR}/ThirdParty/libusb-1.0.21/include"
   PRIVATE "${CMAKE_CURRENT_SOURCE_DIR}/ThirdParty/Asio/asio-1.12.1/include"
 )
-target_link_libraries(${PROJECT_NAME} "-Wl,--exclude-libs,libusb-1.0.a" "${CMAKE_CURRENT_BINARY_DIR}/ThirdParty/libusb-1.0.21/lib/libusb-1.0.a" pthread udev)
+target_link_libraries(${PROJECT_NAME} pthread)
+
+if(ENABLE_USB)
+  set(LIBUSB_DIR "${CMAKE_CURRENT_SOURCE_DIR}/ThirdParty/libusb/linux/libusb-1.0.21")
+  include(ExternalProject)
+  ExternalProject_Add(libusb-1.0.21
+    SOURCE_DIR ${LIBUSB_DIR}
+    PATCH_COMMAND "bash"
+      "-c"
+      "! [ -x ${LIBUSB_DIR}/configure ] && chmod +x ${LIBUSB_DIR}/configure || :"
+    CONFIGURE_COMMAND "${LIBUSB_DIR}/configure"
+      "CFLAGS=-fPIC"
+      "--prefix=${CMAKE_CURRENT_BINARY_DIR}/ThirdParty/libusb-1.0.21"
+      "--enable-shared=no"
+      "--enable-static=yes"
+    BUILD_COMMAND "bash"
+      "-c"
+      "(make check &> /dev/null || touch ${LIBUSB_DIR}/aclocal.m4 ${LIBUSB_DIR}/Makefile.in ${LIBUSB_DIR}/configure ${LIBUSB_DIR}/config.h.in) && make"
+    INSTALL_COMMAND make install
+  )
+  add_dependencies(${PROJECT_NAME} libusb-1.0.21)
+  target_compile_definitions(${PROJECT_NAME} PUBLIC ENABLE_USB)
+  target_include_directories(${PROJECT_NAME}
+    PRIVATE "${CMAKE_CURRENT_BINARY_DIR}/ThirdParty/libusb-1.0.21/include"
+  )
+  target_link_libraries(${PROJECT_NAME} "-Wl,--exclude-libs,libusb-1.0.a" "${CMAKE_CURRENT_BINARY_DIR}/ThirdParty/libusb-1.0.21/lib/libusb-1.0.a" udev)
+endif() # ENABLE_USB

--- a/win32.cmake
+++ b/win32.cmake
@@ -4,13 +4,6 @@ if(MINGW)
   add_compile_options(-std=c++11)
 endif()
 
-set(LIBUSB_DIR "${CMAKE_CURRENT_SOURCE_DIR}/ThirdParty/libusb/win32/libusb-1.0.21")
-if(MSVC)
-  set(LIBUSB_LIBRARY "${LIBUSB_DIR}/MS32/static/libusb-1.0.lib")
-elseif(MINGW)
-  set(LIBUSB_LIBRARY "${LIBUSB_DIR}/MinGW32/static/libusb-1.0.a")
-endif()
-
 set(SDK_INCLUDE_DIR "${CMAKE_CURRENT_SOURCE_DIR}/Sources/include")
 set(SDK_SRC_DIR "${CMAKE_CURRENT_SOURCE_DIR}/Sources/src")
 
@@ -29,7 +22,18 @@ endif()
 target_include_directories(${PROJECT_NAME}
   PUBLIC "${SDK_INCLUDE_DIR}/public"
   PRIVATE "${SDK_INCLUDE_DIR}/private"
-  PRIVATE "${LIBUSB_DIR}/include"
   PRIVATE "${CMAKE_CURRENT_SOURCE_DIR}/ThirdParty/Asio/asio-1.12.1/include"
 )
-target_link_libraries(${PROJECT_NAME} ${LIBUSB_LIBRARY})
+if(ENABLE_USB)
+  set(LIBUSB_DIR "${CMAKE_CURRENT_SOURCE_DIR}/ThirdParty/libusb/win32/libusb-1.0.21")
+  if(MSVC)
+    set(LIBUSB_LIBRARY "${LIBUSB_DIR}/MS32/static/libusb-1.0.lib")
+  elseif(MINGW)
+    set(LIBUSB_LIBRARY "${LIBUSB_DIR}/MinGW32/static/libusb-1.0.a")
+  endif()
+  target_compile_definitions(${PROJECT_NAME} PUBLIC ENABLE_USB)
+  target_include_directories(${PROJECT_NAME}
+    PRIVATE "${LIBUSB_DIR}/include"
+  )
+  target_link_libraries(${PROJECT_NAME} ${LIBUSB_LIBRARY})
+endif() # ENABLE_USB

--- a/win32.cmake
+++ b/win32.cmake
@@ -24,7 +24,7 @@ set_target_properties(${PROJECT_NAME} PROPERTIES IMPORT_PREFIX "")
 if(BUILD_SHARED_LIBS)
   target_compile_definitions(${PROJECT_NAME} PRIVATE LTME01_SDK_EXPORTS)
 else()
-  target_compile_definitions(${PROJECT_NAME} PRIVATE LTME01_SDK_STATIC)
+  target_compile_definitions(${PROJECT_NAME} PUBLIC LTME01_SDK_STATIC)
 endif()
 target_include_directories(${PROJECT_NAME}
   PUBLIC "${SDK_INCLUDE_DIR}/public"


### PR DESCRIPTION
The scope of compile definition `LTME01_SDK_STATIC` is `PRIVATE`, so users cannot see it.

As a result, when use the sdk with static linkage in windows, the macro `LTME01_SDK_EXPORTS` will fallback into `__declspec(dllimport)` for users.